### PR TITLE
feat: make evaluator acting function slightly more generic

### DIFF
--- a/stoix/systems/ddpg/ff_d4pg.py
+++ b/stoix/systems/ddpg/ff_d4pg.py
@@ -18,7 +18,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import CompositeNetwork
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.postprocessors import tanh_to_spec
@@ -519,7 +519,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params.online,
         config=config,
     )

--- a/stoix/systems/ddpg/ff_ddpg.py
+++ b/stoix/systems/ddpg/ff_ddpg.py
@@ -18,7 +18,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import CompositeNetwork
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.postprocessors import tanh_to_spec
@@ -505,7 +505,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params.online,
         config=config,
     )

--- a/stoix/systems/ddpg/ff_td3.py
+++ b/stoix/systems/ddpg/ff_td3.py
@@ -18,7 +18,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import CompositeNetwork
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.base import MultiNetwork
@@ -528,7 +528,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params.online,
         config=config,
     )

--- a/stoix/systems/mpo/ff_mpo.py
+++ b/stoix/systems/mpo/ff_mpo.py
@@ -18,7 +18,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import CompositeNetwork
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.systems.mpo.discrete_loss import (
@@ -596,7 +596,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params.online,
         config=config,
     )

--- a/stoix/systems/mpo/ff_mpo_continuous.py
+++ b/stoix/systems/mpo/ff_mpo_continuous.py
@@ -18,7 +18,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import CompositeNetwork
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.systems.mpo.continuous_loss import clip_dual_params, mpo_loss
@@ -616,7 +616,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params.online,
         config=config,
     )

--- a/stoix/systems/ppo/ff_dpo_continuous.py
+++ b/stoix/systems/ppo/ff_dpo_continuous.py
@@ -14,7 +14,7 @@ from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.base import FeedForwardCritic as Critic
 from stoix.systems.ppo.types import (
@@ -427,7 +427,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params,
         config=config,
     )

--- a/stoix/systems/ppo/ff_ppo.py
+++ b/stoix/systems/ppo/ff_ppo.py
@@ -14,7 +14,7 @@ from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.base import FeedForwardCritic as Critic
 from stoix.systems.ppo.types import (
@@ -422,7 +422,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params,
         config=config,
     )

--- a/stoix/systems/ppo/ff_ppo_continuous.py
+++ b/stoix/systems/ppo/ff_ppo_continuous.py
@@ -14,7 +14,7 @@ from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.base import FeedForwardCritic as Critic
 from stoix.systems.ppo.types import (
@@ -427,7 +427,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params,
         config=config,
     )

--- a/stoix/systems/ppo/rec_ppo.py
+++ b/stoix/systems/ppo/rec_ppo.py
@@ -14,7 +14,7 @@ from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_rec_distribution_act_fn
 from stoix.networks.base import RecurrentActor as Actor
 from stoix.networks.base import RecurrentCritic as Critic
 from stoix.networks.base import ScannedRNN
@@ -588,7 +588,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_rec_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params,
         config=config,
         use_recurrent_net=True,

--- a/stoix/systems/q_learning/ff_c51.py
+++ b/stoix/systems/q_learning/ff_c51.py
@@ -30,7 +30,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.types import (
     ActorApply,
@@ -423,7 +423,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=eval_q_network,
+        eval_act_fn=get_distribution_act_fn(config, eval_q_network.apply),
         params=learner_state.params.online,
         config=config,
     )

--- a/stoix/systems/q_learning/ff_ddqn.py
+++ b/stoix/systems/q_learning/ff_ddqn.py
@@ -17,7 +17,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.systems.q_learning.types import DQNLearnerState, QsAndTarget, Transition
 from stoix.types import ActorApply, ExperimentOutput, LearnerFn, LogEnvState
@@ -401,7 +401,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=eval_q_network,
+        eval_act_fn=get_distribution_act_fn(config, eval_q_network.apply),
         params=learner_state.params.online,
         config=config,
     )

--- a/stoix/systems/q_learning/ff_dqn.py
+++ b/stoix/systems/q_learning/ff_dqn.py
@@ -17,7 +17,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.systems.q_learning.types import DQNLearnerState, QsAndTarget, Transition
 from stoix.types import ActorApply, ExperimentOutput, LearnerFn, LogEnvState
@@ -400,7 +400,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=eval_q_network,
+        eval_act_fn=get_distribution_act_fn(config, eval_q_network.apply),
         params=learner_state.params.online,
         config=config,
     )

--- a/stoix/systems/q_learning/ff_dqn_reg.py
+++ b/stoix/systems/q_learning/ff_dqn_reg.py
@@ -17,7 +17,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.systems.q_learning.types import DQNLearnerState, QsAndTarget, Transition
 from stoix.types import ActorApply, ExperimentOutput, LearnerFn, LogEnvState
@@ -404,7 +404,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=eval_q_network,
+        eval_act_fn=get_distribution_act_fn(config, eval_q_network.apply),
         params=learner_state.params.online,
         config=config,
     )

--- a/stoix/systems/q_learning/ff_mdqn.py
+++ b/stoix/systems/q_learning/ff_mdqn.py
@@ -17,7 +17,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.systems.q_learning.types import DQNLearnerState, QsAndTarget, Transition
 from stoix.types import ActorApply, ExperimentOutput, LearnerFn, LogEnvState
@@ -404,7 +404,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=eval_q_network,
+        eval_act_fn=get_distribution_act_fn(config, eval_q_network.apply),
         params=learner_state.params.online,
         config=config,
     )

--- a/stoix/systems/q_learning/ff_qr_dqn.py
+++ b/stoix/systems/q_learning/ff_qr_dqn.py
@@ -30,7 +30,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.types import (
     ActorApply,
@@ -435,7 +435,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=eval_q_network,
+        eval_act_fn=get_distribution_act_fn(config, eval_q_network.apply),
         params=learner_state.params.online,
         config=config,
     )

--- a/stoix/systems/sac/ff_sac.py
+++ b/stoix/systems/sac/ff_sac.py
@@ -17,7 +17,7 @@ from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
 from rich.pretty import pprint
 
-from stoix.evaluator import evaluator_setup
+from stoix.evaluator import evaluator_setup, get_distribution_act_fn
 from stoix.networks.base import CompositeNetwork
 from stoix.networks.base import FeedForwardActor as Actor
 from stoix.networks.base import MultiNetwork
@@ -522,7 +522,7 @@ def run_experiment(_config: DictConfig) -> None:
     evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
         eval_env=eval_env,
         key_e=key_e,
-        network=actor_network,
+        eval_act_fn=get_distribution_act_fn(config, actor_network.apply),
         params=learner_state.params.actor_params,
         config=config,
     )

--- a/stoix/types.py
+++ b/stoix/types.py
@@ -97,8 +97,13 @@ LearnerFn = Callable[[StoixState], ExperimentOutput[StoixState]]
 EvalFn = Callable[[FrozenDict, chex.PRNGKey], ExperimentOutput[StoixState]]
 
 ActorApply = Callable[[FrozenDict, Observation], DistributionLike]
+ActFn = Callable[[FrozenDict, Observation, chex.PRNGKey], chex.Array]
 CriticApply = Callable[[FrozenDict, Observation], Value]
+
 RecActorApply = Callable[
     [FrozenDict, HiddenState, RNNObservation], Tuple[HiddenState, DistributionLike]
+]
+RecActFn = Callable[
+    [FrozenDict, HiddenState, RNNObservation, chex.PRNGKey], Tuple[HiddenState, chex.Array]
 ]
 RecCriticApply = Callable[[FrozenDict, HiddenState, RNNObservation], Tuple[HiddenState, Value]]


### PR DESCRIPTION
## What?
Pass in actor fn to evaluator instead of explicitly a network function
## Why?
Makes the evaluator slightly more generic but more work needs to be done here.


