### PR TITLE
chore: fix example's reference to .py in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ we advise users to explicitly install the correct JAX version (see the [official
 To get started with training your first Stoix system, simply run one of the system files. e.g.,
 
 ```bash
-python stoix/systems/ff_ppo.py
+python python stoix/systems/ppo/ff_ppo.py
 ```
 
 Stoix makes use of Hydra for config management. In order to see our default system configs please see the `stoix/configs/` directory. A benefit of Hydra is that configs can either be set in config yaml files or overwritten from the terminal on the fly. For an example of running a system on the CartPole environment, the above code can simply be adapted as follows:
 
 ```bash
-python stoix/systems/ff_ppo.py env=gymnax/cartpole
+python python stoix/systems/ppo/ff_ppo.py env=gymnax/cartpole
 ```
 
 ## Contributing 🤝

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ we advise users to explicitly install the correct JAX version (see the [official
 To get started with training your first Stoix system, simply run one of the system files. e.g.,
 
 ```bash
-python python stoix/systems/ppo/ff_ppo.py
+python stoix/systems/ppo/ff_ppo.py
 ```
 
 Stoix makes use of Hydra for config management. In order to see our default system configs please see the `stoix/configs/` directory. A benefit of Hydra is that configs can either be set in config yaml files or overwritten from the terminal on the fly. For an example of running a system on the CartPole environment, the above code can simply be adapted as follows:
 
 ```bash
-python python stoix/systems/ppo/ff_ppo.py env=gymnax/cartpole
+python stoix/systems/ppo/ff_ppo.py env=gymnax/cartpole
 ```
 
 ## Contributing 🤝


### PR DESCRIPTION
## What?
#42 -- README fix
## Why?
Directory structure changed but this was not updated.
## How?
Just a README change.
## Extra
N/A
