### PR TITLE
chore: return evaluation performance in hydra entrypoint

### DIFF
--- a/stoix/configs/env/brax/ant.yaml
+++ b/stoix/configs/env/brax/ant.yaml
@@ -8,3 +8,7 @@ scenario:
 kwargs: {
   backend: spring
 }
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/brax/halfcheetah.yaml
+++ b/stoix/configs/env/brax/halfcheetah.yaml
@@ -8,3 +8,7 @@ scenario:
 kwargs: {
   backend: spring
 }
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/brax/humanoid.yaml
+++ b/stoix/configs/env/brax/humanoid.yaml
@@ -8,3 +8,7 @@ scenario:
 kwargs: {
   backend: spring
 }
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/craftax/classic_pixels.yaml
+++ b/stoix/configs/env/craftax/classic_pixels.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: classic_pixels
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/craftax/classic_symbolic.yaml
+++ b/stoix/configs/env/craftax/classic_symbolic.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: classic_symbolic
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/craftax/pixels.yaml
+++ b/stoix/configs/env/craftax/pixels.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: pixels
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/craftax/symbolic.yaml
+++ b/stoix/configs/env/craftax/symbolic.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: symbolic
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/debug/identity_game.yaml
+++ b/stoix/configs/env/debug/identity_game.yaml
@@ -7,3 +7,7 @@ scenario:
 
 kwargs:
   num_actions: 8
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/debug/sequence_game.yaml
+++ b/stoix/configs/env/debug/sequence_game.yaml
@@ -7,3 +7,7 @@ scenario:
 
 kwargs:
   num_actions: 8
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/acrobot.yaml
+++ b/stoix/configs/env/gymnax/acrobot.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: acrobot
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/asterix.yaml
+++ b/stoix/configs/env/gymnax/asterix.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: asterix
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/breakout.yaml
+++ b/stoix/configs/env/gymnax/breakout.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: breakout
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/cartpole.yaml
+++ b/stoix/configs/env/gymnax/cartpole.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: cartpole
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/freeway.yaml
+++ b/stoix/configs/env/gymnax/freeway.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: freeway
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/mountain_car.yaml
+++ b/stoix/configs/env/gymnax/mountain_car.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: mountain_car
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/mountain_car_continuous.yaml
+++ b/stoix/configs/env/gymnax/mountain_car_continuous.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: mountain_car_continuous
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/pendulum.yaml
+++ b/stoix/configs/env/gymnax/pendulum.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: pendulum
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/gymnax/space_invaders.yaml
+++ b/stoix/configs/env/gymnax/space_invaders.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: space_invaders
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jaxmarl/mabrax.yaml
+++ b/stoix/configs/env/jaxmarl/mabrax.yaml
@@ -18,3 +18,7 @@ kwargs:
   homogenisation_method: max # Default is None. Options: [max, concat] if dimensions of observations and actions are not homogeneous across agents,
   # "max" adds one-hot for the agent's ID. In this case, system.add_agent_id should be set to False.
   # Note: In this case, the agent's ID will be added to the global state within the wrapper if `add_agent_ids_to_state` is True.
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jaxmarl/mpe.yaml
+++ b/stoix/configs/env/jaxmarl/mpe.yaml
@@ -11,3 +11,7 @@ add_global_state : False # Adds the global state to the observations.
 
 kwargs:
   num_agents : 1
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jaxmarl/smax.yaml
+++ b/stoix/configs/env/jaxmarl/smax.yaml
@@ -14,3 +14,7 @@ kwargs:
   see_enemy_actions: True # Whether to enable enemy vision. If True, the enemy will be able to see the actions of the agent.
   walls_cause_death: True # Whether to kill the agent if it collides with a wall.
   attack_mode: "closest" # "closest" or "random". Whether to attack the closest enemy or a random enemy.
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jumanji/2048.yaml
+++ b/stoix/configs/env/jumanji/2048.yaml
@@ -9,3 +9,7 @@ scenario:
   task_name: game_2048
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jumanji/connector.yaml
+++ b/stoix/configs/env/jumanji/connector.yaml
@@ -13,3 +13,7 @@ kwargs:
     _target_: jumanji.environments.routing.connector.generator.RandomWalkGenerator
     grid_size: 6
     num_agents: 2
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jumanji/rware.yaml
+++ b/stoix/configs/env/jumanji/rware.yaml
@@ -17,3 +17,7 @@ kwargs:
     num_agents: 4
     sensor_range: 1
     request_queue_size: 8
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jumanji/snake.yaml
+++ b/stoix/configs/env/jumanji/snake.yaml
@@ -12,3 +12,7 @@ kwargs: {
   num_rows: 6,
   num_cols: 6,
 }
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/jumanji/sokoban.yaml
+++ b/stoix/configs/env/jumanji/sokoban.yaml
@@ -9,3 +9,7 @@ scenario:
   task_name: sokoban
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/minigrid/minigrid_doorkey_5x5.yaml
+++ b/stoix/configs/env/minigrid/minigrid_doorkey_5x5.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: minigrid_doorkey_5x5
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/env/minigrid/minigrid_empty_6x6.yaml
+++ b/stoix/configs/env/minigrid/minigrid_empty_6x6.yaml
@@ -6,3 +6,7 @@ scenario:
   task_name: minigrid_empty_6x6
 
 kwargs: {}
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return

--- a/stoix/configs/hyperparameter_sweep.yaml
+++ b/stoix/configs/hyperparameter_sweep.yaml
@@ -1,0 +1,26 @@
+# Example of a hyperparameter sweep configuration file
+
+defaults:
+  - logger: base_logger
+  - arch: anakin
+  - system: ff_ppo
+  - network: mlp
+  - env: gymnax/cartpole
+  - override hydra/sweeper: optuna
+  - override hydra/sweeper/sampler: tpe
+  - _self_
+
+hydra:
+  mode: MULTIRUN
+  sweeper:
+    direction: maximize
+    study_name: ${system.system_name}_${env.scenario.task_name}_sweep
+    storage: null
+    n_trials: 5
+    n_jobs: 1
+    sampler:
+      seed: ${arch.seed}
+    params:
+      system.clip_eps: range(0.1, 0.3, step=0.1)
+      system.gae_lambda: range(0, 1, step=0.05)
+      system.ppo_epochs: range(1, 10, step=1)

--- a/stoix/systems/awr/ff_awr.py
+++ b/stoix/systems/awr/ff_awr.py
@@ -470,7 +470,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -604,18 +604,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_awr.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}AWR experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/awr/ff_awr_continuous.py
+++ b/stoix/systems/awr/ff_awr_continuous.py
@@ -475,7 +475,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -609,20 +609,29 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_awr_continuous.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}AWR experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/awr/ff_awr_continuous.py
+++ b/stoix/systems/awr/ff_awr_continuous.py
@@ -613,10 +613,6 @@ def run_experiment(_config: DictConfig) -> float:
     # calculated, this will be the final evaluation run.
     eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
     return eval_performance
-    # Record the performance for the final evaluation run. If the absolute metric is not
-    # calculated, this will be the final evaluation run.
-    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
-    return eval_performance
 
 
 @hydra.main(

--- a/stoix/systems/ddpg/ff_d4pg.py
+++ b/stoix/systems/ddpg/ff_d4pg.py
@@ -491,7 +491,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -625,18 +625,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_d4pg.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}D4PG experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/ddpg/ff_ddpg.py
+++ b/stoix/systems/ddpg/ff_ddpg.py
@@ -477,7 +477,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -611,18 +611,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_ddpg.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}DDPG experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/ddpg/ff_td3.py
+++ b/stoix/systems/ddpg/ff_td3.py
@@ -500,7 +500,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -634,18 +634,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_td3.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}TD3 experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/mpo/ff_mpo.py
+++ b/stoix/systems/mpo/ff_mpo.py
@@ -568,7 +568,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -702,18 +702,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_mpo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}MPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/mpo/ff_mpo_continuous.py
+++ b/stoix/systems/mpo/ff_mpo_continuous.py
@@ -588,7 +588,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -722,20 +722,25 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_mpo_continuous.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}MPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/ppo/ff_dpo_continuous.py
+++ b/stoix/systems/ppo/ff_dpo_continuous.py
@@ -404,7 +404,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -539,20 +539,25 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_dpo_continuous.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}DPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/ppo/ff_ppo.py
+++ b/stoix/systems/ppo/ff_ppo.py
@@ -394,7 +394,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -529,18 +529,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_ppo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}PPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/ppo/ff_ppo_continuous.py
+++ b/stoix/systems/ppo/ff_ppo_continuous.py
@@ -404,7 +404,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -539,20 +539,24 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_ppo_continuous.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
-
+    eval_performance = run_experiment(cfg)
     print(f"{Fore.CYAN}{Style.BRIGHT}PPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/ppo/rec_ppo.py
+++ b/stoix/systems/ppo/rec_ppo.py
@@ -568,7 +568,7 @@ def learner_setup(
     return learn, actor_network, actor_rnn, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -711,18 +711,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_rec_ppo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}Recurrent PPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_c51.py
+++ b/stoix/systems/q_learning/ff_c51.py
@@ -401,7 +401,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -531,18 +531,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_c51.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}C51 experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_ddqn.py
+++ b/stoix/systems/q_learning/ff_ddqn.py
@@ -379,7 +379,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -509,18 +509,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_ddqn.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}DDQN experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_dqn.py
+++ b/stoix/systems/q_learning/ff_dqn.py
@@ -378,7 +378,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -508,18 +508,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_dqn.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}DQN experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_dqn_reg.py
+++ b/stoix/systems/q_learning/ff_dqn_reg.py
@@ -382,7 +382,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -512,18 +512,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_dqn_reg.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}DQN-Reg experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_dueling_dqn.py
+++ b/stoix/systems/q_learning/ff_dueling_dqn.py
@@ -377,7 +377,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -507,20 +507,25 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_dueling_dqn.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}Dueling DQN experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_mdqn.py
+++ b/stoix/systems/q_learning/ff_mdqn.py
@@ -382,7 +382,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -512,18 +512,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_mdqn.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}MDQN experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/q_learning/ff_qr_dqn.py
+++ b/stoix/systems/q_learning/ff_qr_dqn.py
@@ -413,7 +413,7 @@ def learner_setup(
     return learn, eval_q_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -543,18 +543,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_qr_dqn.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}QR-DQN experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/sac/ff_sac.py
+++ b/stoix/systems/sac/ff_sac.py
@@ -499,7 +499,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -633,18 +633,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_sac.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}SAC experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/search/ff_az.py
+++ b/stoix/systems/search/ff_az.py
@@ -546,7 +546,7 @@ def learner_setup(
     return learn, root_fn, search_apply_fn, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -682,18 +682,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_az.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}AlphaZero experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/search/ff_mz.py
+++ b/stoix/systems/search/ff_mz.py
@@ -699,7 +699,7 @@ def learner_setup(
     return learn, root_fn, search_apply_fn, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -835,18 +835,23 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(config_path="../../configs", config_name="default_ff_mz.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}MuZero experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/search/ff_sampled_az.py
+++ b/stoix/systems/search/ff_sampled_az.py
@@ -651,7 +651,7 @@ def learner_setup(
     return learn, root_fn, search_apply_fn, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -787,20 +787,25 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_sampled_az.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}Sampled AlphaZero experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/search/ff_sampled_mz.py
+++ b/stoix/systems/search/ff_sampled_mz.py
@@ -802,7 +802,7 @@ def learner_setup(
     return learn, root_fn, search_apply_fn, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -938,20 +938,25 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_sampled_mz.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}Sampled MuZero experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/vpg/ff_reinforce.py
+++ b/stoix/systems/vpg/ff_reinforce.py
@@ -315,7 +315,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -450,20 +450,25 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
     config_path="../../configs", config_name="default_ff_reinforce.yaml", version_base="1.2"
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}REINFORCE with Baseline experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/stoix/systems/vpg/ff_reinforce_continuous.py
+++ b/stoix/systems/vpg/ff_reinforce_continuous.py
@@ -323,7 +323,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -458,6 +458,10 @@ def run_experiment(_config: DictConfig) -> None:
 
     # Stop the logger.
     logger.stop()
+    # Record the performance for the final evaluation run. If the absolute metric is not
+    # calculated, this will be the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
 
 
 @hydra.main(
@@ -465,15 +469,16 @@ def run_experiment(_config: DictConfig) -> None:
     config_name="default_ff_reinforce_continuous.yaml",
     version_base="1.2",
 )
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
+    eval_performance = run_experiment(cfg)
 
     print(f"{Fore.CYAN}{Style.BRIGHT}REINFORCE with Baseline experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What?
Return the evaluation performance of the experiments from the hydra entry point
## Why?
Easily allows one to perform hyper parameter sweeps.
## How?
Using hydra optuna multi run

