### PR TITLE
[FEATURE] Implement self-play for two-player zero-sum games

### DIFF
--- a/stoix/systems/self-play/ff_dqn.py
+++ b/stoix/systems/self-play/ff_dqn.py
@@ -155,7 +155,9 @@ def get_learner_fn(
                 q_t = q_apply_fn(target_q_params, transitions.next_obs).preferences
 
                 # Cast and clip rewards.
-                discount = 1.0 - transitions.done.astype(jnp.float32)
+                discount = (
+                    1.0 - transitions.done.astype(jnp.float32)
+                ) * -1  # reverse the discount to obtain zero-sum returns
                 d_t = (discount * config.system.gamma).astype(jnp.float32)
                 r_t = jnp.clip(
                     transitions.reward, -config.system.max_abs_reward, config.system.max_abs_reward


### PR DESCRIPTION
Issue: #99 

Description:
Add self-play versions of DQN and PPO for two-player zero-sum games in [PGX](https://github.com/sotetsuk/pgx/tree/main) environments.

Checklist:

 - [ ] Determine how to keep the value estimation consistent (e.g. flip the board or reverse the discount for opponent values)
 - [ ] Add PGX environment configs
 - [ ] Implement self-play for DQN
 - [ ] And for PPO
 - [ ] (optional) If possible, for AlphaZero