### PR TITLE
chore: refactor types

### DIFF
--- a/.github/workflows/run_algs.yaml
+++ b/.github/workflows/run_algs.yaml
@@ -1,0 +1,36 @@
+name: Check Algorithms 🧪
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test-algorithms:
+    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}"
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout stoix
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+            python-version: "${{ matrix.python-version }}"
+      - name: Install python dependencies 🔧
+        run: pip install .
+
+      - name: Make Bash Script Executable
+        run: chmod +x bash_scripts/run-algorithms.sh
+
+      - name: Run Bash Script
+        run: ./bash_scripts/run-algorithms.sh

--- a/.github/workflows/run_algs.yaml
+++ b/.github/workflows/run_algs.yaml
@@ -13,7 +13,7 @@ jobs:
   test-algorithms:
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/bash_scripts/run-algorithms.sh
+++ b/bash_scripts/run-algorithms.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Running All Algorithms..."
+
+python stoix/systems/ppo/anakin/ff_ppo.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/ppo/anakin/ff_ppo_continuous.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/q_learning/ff_dqn.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/q_learning/ff_ddqn.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/q_learning/ff_mdqn.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/q_learning/ff_c51.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/q_learning/ff_qr_dqn.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/sac/ff_sac.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/ddpg/ff_ddpg.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/ddpg/ff_td3.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/vpg/ff_reinforce.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/awr/ff_awr.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8
+python stoix/systems/mpo/ff_mpo.py arch.total_timesteps=300 arch.total_num_envs=8 arch.num_evaluation=1 system.rollout_length=8

--- a/stoix/base_types.py
+++ b/stoix/base_types.py
@@ -161,7 +161,14 @@ StoixTransition = TypeVar(
 )
 
 
-class ExperimentOutput(NamedTuple, Generic[StoixState]):
+class SebulbaExperimentOutput(NamedTuple, Generic[StoixState]):
+    """Experiment output."""
+
+    learner_state: StoixState
+    train_metrics: Dict[str, chex.Array]
+
+
+class AnakinExperimentOutput(NamedTuple, Generic[StoixState]):
     """Experiment output."""
 
     learner_state: StoixState
@@ -169,10 +176,18 @@ class ExperimentOutput(NamedTuple, Generic[StoixState]):
     train_metrics: Dict[str, chex.Array]
 
 
+class EvaluationOutput(NamedTuple, Generic[StoixState]):
+    """Evaluation output."""
+
+    learner_state: StoixState
+    episode_metrics: Dict[str, chex.Array]
+
+
 RNNObservation: TypeAlias = Tuple[Observation, Done]
-LearnerFn = Callable[[StoixState], ExperimentOutput[StoixState]]
-SebulbaLearnerFn = Callable[[StoixState, StoixTransition], ExperimentOutput[StoixState]]
-EvalFn = Callable[[FrozenDict, chex.PRNGKey], ExperimentOutput[StoixState]]
+LearnerFn = Callable[[StoixState], AnakinExperimentOutput[StoixState]]
+SebulbaLearnerFn = Callable[[StoixState, StoixTransition], SebulbaExperimentOutput[StoixState]]
+EvalFn = Callable[[FrozenDict, chex.PRNGKey], EvaluationOutput[StoixState]]
+SebulbaEvalFn = Callable[[FrozenDict, chex.PRNGKey], Dict[str, chex.Array]]
 
 ActorApply = Callable[..., DistributionLike]
 

--- a/stoix/systems/awr/ff_awr.py
+++ b/stoix/systems/awr/ff_awr.py
@@ -22,8 +22,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
 )
@@ -323,7 +323,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: AWRLearnerState) -> ExperimentOutput[AWRLearnerState]:
+    def learner_fn(learner_state: AWRLearnerState) -> AnakinExperimentOutput[AWRLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -336,7 +336,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/awr/ff_awr_continuous.py
+++ b/stoix/systems/awr/ff_awr_continuous.py
@@ -22,8 +22,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
 )
@@ -323,7 +323,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: AWRLearnerState) -> ExperimentOutput[AWRLearnerState]:
+    def learner_fn(learner_state: AWRLearnerState) -> AnakinExperimentOutput[AWRLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -336,7 +336,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ddpg/ff_d4pg.py
+++ b/stoix/systems/ddpg/ff_d4pg.py
@@ -20,8 +20,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     ContinuousQApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
     Observation,
@@ -347,7 +347,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -360,7 +362,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ddpg/ff_ddpg.py
+++ b/stoix/systems/ddpg/ff_ddpg.py
@@ -20,8 +20,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     ContinuousQApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
     Observation,
@@ -309,7 +309,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -323,7 +325,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ddpg/ff_td3.py
+++ b/stoix/systems/ddpg/ff_td3.py
@@ -20,8 +20,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     ContinuousQApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
     Observation,
@@ -327,7 +327,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -341,7 +343,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/mpo/ff_mpo.py
+++ b/stoix/systems/mpo/ff_mpo.py
@@ -20,8 +20,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     ContinuousQApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
     OnlineAndTarget,
@@ -406,7 +406,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: MPOLearnerState) -> ExperimentOutput[MPOLearnerState]:
+    def learner_fn(learner_state: MPOLearnerState) -> AnakinExperimentOutput[MPOLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -419,7 +419,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/mpo/ff_mpo_continuous.py
+++ b/stoix/systems/mpo/ff_mpo_continuous.py
@@ -20,8 +20,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     ContinuousQApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
     OnlineAndTarget,
@@ -422,7 +422,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: MPOLearnerState) -> ExperimentOutput[MPOLearnerState]:
+    def learner_fn(learner_state: MPOLearnerState) -> AnakinExperimentOutput[MPOLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -435,7 +435,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/mpo/ff_vmpo.py
+++ b/stoix/systems/mpo/ff_vmpo.py
@@ -17,8 +17,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnlineAndTarget,
 )
@@ -305,7 +305,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: VMPOLearnerState) -> ExperimentOutput[VMPOLearnerState]:
+    def learner_fn(learner_state: VMPOLearnerState) -> AnakinExperimentOutput[VMPOLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -318,7 +318,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/mpo/ff_vmpo_continuous.py
+++ b/stoix/systems/mpo/ff_vmpo_continuous.py
@@ -18,8 +18,8 @@ from tensorflow_probability.substrates.jax.distributions import Independent, Nor
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnlineAndTarget,
 )
@@ -362,7 +362,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: VMPOLearnerState) -> ExperimentOutput[VMPOLearnerState]:
+    def learner_fn(learner_state: VMPOLearnerState) -> AnakinExperimentOutput[VMPOLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -375,7 +375,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ppo/anakin/ff_dpo_continuous.py
+++ b/stoix/systems/ppo/anakin/ff_dpo_continuous.py
@@ -18,8 +18,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -280,7 +280,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -301,7 +303,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -18,8 +18,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -275,7 +275,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -296,7 +298,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ppo/anakin/ff_ppo_continuous.py
+++ b/stoix/systems/ppo/anakin/ff_ppo_continuous.py
@@ -18,8 +18,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -281,7 +281,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -302,7 +304,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ppo/anakin/ff_ppo_penalty.py
+++ b/stoix/systems/ppo/anakin/ff_ppo_penalty.py
@@ -18,8 +18,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -284,7 +284,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -305,7 +307,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ppo/anakin/ff_ppo_penalty_continuous.py
+++ b/stoix/systems/ppo/anakin/ff_ppo_penalty_continuous.py
@@ -18,8 +18,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -289,7 +289,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -310,7 +312,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/ppo/anakin/rec_ppo.py
+++ b/stoix/systems/ppo/anakin/rec_ppo.py
@@ -17,7 +17,7 @@ from rich.pretty import pprint
 from stoix.base_types import (
     ActorCriticOptStates,
     ActorCriticParams,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     RecActorApply,
     RecCriticApply,
@@ -400,7 +400,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: RNNLearnerState) -> ExperimentOutput[RNNLearnerState]:
+    def learner_fn(learner_state: RNNLearnerState) -> AnakinExperimentOutput[RNNLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -423,7 +423,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_c51.py
+++ b/stoix/systems/q_learning/ff_c51.py
@@ -32,7 +32,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     Observation,
@@ -240,7 +240,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -253,7 +255,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_ddqn.py
+++ b/stoix/systems/q_learning/ff_ddqn.py
@@ -19,7 +19,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     OffPolicyLearnerState,
@@ -235,7 +235,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -249,7 +251,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_dqn.py
+++ b/stoix/systems/q_learning/ff_dqn.py
@@ -19,7 +19,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     OffPolicyLearnerState,
@@ -234,7 +234,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -248,7 +250,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_dqn_reg.py
+++ b/stoix/systems/q_learning/ff_dqn_reg.py
@@ -19,7 +19,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     OffPolicyLearnerState,
@@ -238,7 +238,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -252,7 +254,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_mdqn.py
+++ b/stoix/systems/q_learning/ff_mdqn.py
@@ -19,7 +19,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     OffPolicyLearnerState,
@@ -238,7 +238,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -252,7 +254,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_qr_dqn.py
+++ b/stoix/systems/q_learning/ff_qr_dqn.py
@@ -32,7 +32,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     Observation,
@@ -254,7 +254,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -267,7 +269,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/q_learning/ff_rainbow.py
+++ b/stoix/systems/q_learning/ff_rainbow.py
@@ -33,7 +33,7 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
-    ExperimentOutput,
+    AnakinExperimentOutput,
     LearnerFn,
     LogEnvState,
     Observation,
@@ -302,7 +302,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -315,7 +317,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/sac/ff_sac.py
+++ b/stoix/systems/sac/ff_sac.py
@@ -19,8 +19,8 @@ from rich.pretty import pprint
 
 from stoix.base_types import (
     ActorApply,
+    AnakinExperimentOutput,
     ContinuousQApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
     OffPolicyLearnerState,
@@ -321,7 +321,9 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OffPolicyLearnerState) -> ExperimentOutput[OffPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OffPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OffPolicyLearnerState]:
         """Learner function.
 
         This function represents the learner, it updates the network parameters
@@ -334,7 +336,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/search/evaluator.py
+++ b/stoix/systems/search/evaluator.py
@@ -7,7 +7,7 @@ from flax.core.frozen_dict import FrozenDict
 from jumanji.env import Environment
 from omegaconf import DictConfig
 
-from stoix.base_types import EvalFn, EvalState, ExperimentOutput
+from stoix.base_types import EvalFn, EvalState, EvaluationOutput
 from stoix.systems.search.search_types import RootFnApply, SearchApply
 from stoix.utils.jax_utils import unreplicate_batch_dim
 
@@ -68,7 +68,7 @@ def get_search_evaluator_fn(
 
         return eval_metrics
 
-    def evaluator_fn(trained_params: FrozenDict, key: chex.PRNGKey) -> ExperimentOutput[EvalState]:
+    def evaluator_fn(trained_params: FrozenDict, key: chex.PRNGKey) -> EvaluationOutput[EvalState]:
         """Evaluator function."""
 
         # Initialise environment states and timesteps.
@@ -99,10 +99,9 @@ def get_search_evaluator_fn(
             axis_name="eval_batch",
         )(trained_params, eval_state)
 
-        return ExperimentOutput(
+        return EvaluationOutput(
             learner_state=eval_state,
             episode_metrics=eval_metrics,
-            train_metrics={},
         )
 
     return evaluator_fn

--- a/stoix/systems/search/ff_az.py
+++ b/stoix/systems/search/ff_az.py
@@ -25,8 +25,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
 )
@@ -354,7 +354,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: ZLearnerState) -> ExperimentOutput[ZLearnerState]:
+    def learner_fn(learner_state: ZLearnerState) -> AnakinExperimentOutput[ZLearnerState]:
         """Learner function."""
 
         batched_update_step = jax.vmap(_update_step, in_axes=(0, None), axis_name="batch")
@@ -362,7 +362,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/search/ff_mz.py
+++ b/stoix/systems/search/ff_mz.py
@@ -23,9 +23,9 @@ from rich.pretty import pprint
 from stoix.base_types import (
     ActorApply,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
     DistributionCriticApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
 )
@@ -430,7 +430,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: ZLearnerState) -> ExperimentOutput[ZLearnerState]:
+    def learner_fn(learner_state: ZLearnerState) -> AnakinExperimentOutput[ZLearnerState]:
         """Learner function."""
 
         batched_update_step = jax.vmap(_update_step, in_axes=(0, None), axis_name="batch")
@@ -438,7 +438,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/search/ff_sampled_az.py
+++ b/stoix/systems/search/ff_sampled_az.py
@@ -25,8 +25,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
 )
@@ -488,7 +488,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: ZLearnerState) -> ExperimentOutput[ZLearnerState]:
+    def learner_fn(learner_state: ZLearnerState) -> AnakinExperimentOutput[ZLearnerState]:
         """Learner function."""
 
         batched_update_step = jax.vmap(_update_step, in_axes=(0, None), axis_name="batch")
@@ -496,7 +496,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/search/ff_sampled_mz.py
+++ b/stoix/systems/search/ff_sampled_mz.py
@@ -23,9 +23,9 @@ from rich.pretty import pprint
 from stoix.base_types import (
     ActorApply,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
     DistributionCriticApply,
-    ExperimentOutput,
     LearnerFn,
     LogEnvState,
 )
@@ -561,7 +561,7 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: ZLearnerState) -> ExperimentOutput[ZLearnerState]:
+    def learner_fn(learner_state: ZLearnerState) -> AnakinExperimentOutput[ZLearnerState]:
         """Learner function."""
 
         batched_update_step = jax.vmap(_update_step, in_axes=(0, None), axis_name="batch")
@@ -569,7 +569,7 @@ def get_learner_fn(
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/vpg/ff_reinforce.py
+++ b/stoix/systems/vpg/ff_reinforce.py
@@ -19,8 +19,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -200,14 +200,16 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
 
         batched_update_step = jax.vmap(_update_step, in_axes=(0, None), axis_name="batch")
 
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,

--- a/stoix/systems/vpg/ff_reinforce_continuous.py
+++ b/stoix/systems/vpg/ff_reinforce_continuous.py
@@ -19,8 +19,8 @@ from stoix.base_types import (
     ActorApply,
     ActorCriticOptStates,
     ActorCriticParams,
+    AnakinExperimentOutput,
     CriticApply,
-    ExperimentOutput,
     LearnerFn,
     OnPolicyLearnerState,
 )
@@ -198,14 +198,16 @@ def get_learner_fn(
         metric = traj_batch.info
         return learner_state, (metric, loss_info)
 
-    def learner_fn(learner_state: OnPolicyLearnerState) -> ExperimentOutput[OnPolicyLearnerState]:
+    def learner_fn(
+        learner_state: OnPolicyLearnerState,
+    ) -> AnakinExperimentOutput[OnPolicyLearnerState]:
 
         batched_update_step = jax.vmap(_update_step, in_axes=(0, None), axis_name="batch")
 
         learner_state, (episode_info, loss_info) = jax.lax.scan(
             batched_update_step, learner_state, None, config.arch.num_updates_per_eval
         )
-        return ExperimentOutput(
+        return AnakinExperimentOutput(
             learner_state=learner_state,
             episode_metrics=episode_info,
             train_metrics=loss_info,


### PR DESCRIPTION
## What?
Refactor the way metrics are returned for anakin and sebulba systems.
## Why?
To remove redundant variables and make the code a little cleaner in my opinion.
## How?
Create new experiment and evaluation output types.
## Extra
Remove some legacy comments from sebulba PR.
