### PR TITLE
Fix: Sebulba PPO Metrics

### DIFF
--- a/stoix/evaluator.py
+++ b/stoix/evaluator.py
@@ -371,7 +371,7 @@ def get_sebulba_eval_fn(
     # we will run all episodes in parallel.
     # Otherwise we will run `num_envs` parallel envs and loop enough times
     # so that we do at least `eval_episodes` number of episodes.
-    n_parallel_envs = int(min(eval_episodes, config.arch.num_envs))
+    n_parallel_envs = int(min(eval_episodes, config.arch.total_num_envs))
     episode_loops = math.ceil(eval_episodes / n_parallel_envs)
     envs = env_factory(n_parallel_envs)
     cpu = jax.devices("cpu")[0]

--- a/stoix/systems/ppo/sebulba/ff_ppo.py
+++ b/stoix/systems/ppo/sebulba/ff_ppo.py
@@ -857,7 +857,9 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     start = time.monotonic()
     eval_performance = run_experiment(cfg)
     end = time.monotonic()
-    print(f"{Fore.CYAN}{Style.BRIGHT}PPO experiment completed in {end - start:.2f} seconds.{Style.RESET_ALL}")
+    print(
+        f"{Fore.CYAN}{Style.BRIGHT}PPO experiment completed in {end - start:.2f}s.{Style.RESET_ALL}"
+    )
     return eval_performance
 
 

--- a/stoix/systems/ppo/sebulba/ff_ppo.py
+++ b/stoix/systems/ppo/sebulba/ff_ppo.py
@@ -807,6 +807,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Now we stop the actors and params sources
     print(f"{Fore.MAGENTA}{Style.BRIGHT}Closing actors...{Style.RESET_ALL}")
+    pipeline.clear()
     for actor in actor_threads:
         # We clear the pipeline before stopping each actor thread
         # since actors can be blocked on the pipeline

--- a/stoix/utils/total_timestep_checker.py
+++ b/stoix/utils/total_timestep_checker.py
@@ -5,38 +5,33 @@ from omegaconf import DictConfig
 def check_total_timesteps(config: DictConfig) -> DictConfig:
     """Check if total_timesteps is set, if not, set it based on the other parameters"""
 
-    # Check if the number of devices is set in the config
-    # If not, it is assumed that the number of devices is 1
-    # For the case of using a sebulba config, the number of
-    # devices is set to 1 for the calculation
-    # of the number of environments per device, etc
-    if "num_devices" not in config:
-        num_devices = 1
+    # If num_devices and update_batch_size are not in the config,
+    # usually this means a sebulba config is being used.
+    if "num_devices" not in config and "update_batch_size" not in config.arch:
+        return check_total_timesteps_sebulba(config)
     else:
-        num_devices = config.num_devices
+        return check_total_timesteps_anakin(config)
 
-    # If update_batch_size is not in the config, usually this means a sebulba config is being used.
-    if "update_batch_size" not in config.arch:
-        update_batch_size = 1
-        print(f"{Fore.YELLOW}{Style.BRIGHT}Using Sebulba System!{Style.RESET_ALL}")
-    else:
-        update_batch_size = config.arch.update_batch_size
-        print(f"{Fore.YELLOW}{Style.BRIGHT}Using Anakin System!{Style.RESET_ALL}")
 
-    assert config.arch.total_num_envs % (num_devices * update_batch_size) == 0, (
+def check_total_timesteps_anakin(config: DictConfig) -> DictConfig:
+    """Check if total_timesteps is set, if not, set it based on the other parameters"""
+
+    print(f"{Fore.YELLOW}{Style.BRIGHT}Using Anakin System!{Style.RESET_ALL}")
+
+    assert config.arch.total_num_envs % (config.num_devices * config.arch.update_batch_size) == 0, (
         f"{Fore.RED}{Style.BRIGHT}The total number of environments "
         + f"should be divisible by the n_devices*update_batch_size!{Style.RESET_ALL}"
     )
     config.arch.num_envs = int(
-        config.arch.total_num_envs // (num_devices * update_batch_size)
+        config.arch.total_num_envs // (config.num_devices * config.arch.update_batch_size)
     )  # Number of environments per device
 
     if config.arch.total_timesteps is None:
         config.arch.total_timesteps = (
-            num_devices
+            config.num_devices
             * config.arch.num_updates
             * config.system.rollout_length
-            * update_batch_size
+            * config.arch.update_batch_size
             * config.arch.num_envs
         )
         print(
@@ -49,9 +44,9 @@ def check_total_timesteps(config: DictConfig) -> DictConfig:
         config.arch.num_updates = (
             config.arch.total_timesteps
             // config.system.rollout_length
-            // update_batch_size
+            // config.arch.update_batch_size
             // config.arch.num_envs
-            // num_devices
+            // config.num_devices
         )
         print(
             f"{Fore.YELLOW}{Style.BRIGHT}Changing the number of updates "
@@ -63,10 +58,10 @@ def check_total_timesteps(config: DictConfig) -> DictConfig:
     # Calculate the actual number of timesteps that will be run
     num_updates_per_eval = config.arch.num_updates // config.arch.num_evaluation
     steps_per_rollout = (
-        num_devices
+        config.num_devices
         * num_updates_per_eval
         * config.system.rollout_length
-        * update_batch_size
+        * config.arch.update_batch_size
         * config.arch.num_envs
     )
     total_actual_timesteps = steps_per_rollout * config.arch.num_evaluation
@@ -77,6 +72,84 @@ def check_total_timesteps(config: DictConfig) -> DictConfig:
         f"{config.arch.total_timesteps - total_actual_timesteps} timesteps! To change this, "
         f"see total_timestep_checker.py in the utils folder. "
         f"{Style.RESET_ALL}"
+    )
+
+    return config
+
+
+def check_total_timesteps_sebulba(config: DictConfig) -> DictConfig:
+    """Check if total_timesteps is set, if not, set it based on the other parameters"""
+
+    print(f"{Fore.YELLOW}{Style.BRIGHT}Using Sebulba System!{Style.RESET_ALL}")
+
+    assert (
+        config.arch.total_num_envs % (config.num_actor_devices * config.arch.actor.actor_per_device)
+        == 0
+    ), (
+        f"{Fore.RED}{Style.BRIGHT}The total number of environments "
+        + f"should be divisible by the number of actor devices * actor_per_device!{Style.RESET_ALL}"
+    )
+    # We first simply take the total number of envs and divide by the number of actor devices
+    # to get the number of envs per actor device
+    num_envs_per_actor_device = config.arch.total_num_envs // config.num_actor_devices
+    # We then divide this by the number of actors per device to get the number of envs per actor
+    num_envs_per_actor = int(num_envs_per_actor_device // config.arch.actor.actor_per_device)
+    config.arch.actor.num_envs_per_actor = num_envs_per_actor
+
+    # We base the total number of timesteps based on the number of steps the learner consumes
+    if config.arch.total_timesteps is None:
+        config.arch.total_timesteps = (
+            config.arch.num_updates
+            * config.system.rollout_length
+            * config.arch.actor.num_envs_per_actor
+        )
+        print(
+            f"{Fore.YELLOW}{Style.BRIGHT}Changing the total number of timesteps "
+            + f"to {config.arch.total_timesteps}: If you want to train"
+            + " for a specific number of timesteps, please set num_updates to None!"
+            + f"{Style.RESET_ALL}"
+        )
+    else:
+        config.arch.num_updates = (
+            config.arch.total_timesteps
+            // config.system.rollout_length
+            // config.arch.actor.num_envs_per_actor
+        )
+        print(
+            f"{Fore.YELLOW}{Style.BRIGHT}Changing the number of updates "
+            + f"to {config.arch.num_updates}: If you want to train"
+            + " for a specific number of updates, please set total_timesteps to None!"
+            + f"{Style.RESET_ALL}"
+        )
+
+    # Calculate the number of updates per evaluation
+    config.arch.num_updates_per_eval = int(config.arch.num_updates // config.arch.num_evaluation)
+    # Get the number of steps consumed by the learner per learner step
+    steps_per_learner_step = config.system.rollout_length * config.arch.actor.num_envs_per_actor
+    # Get the number of steps consumed by the learner per evaluation
+    steps_consumed_per_eval = steps_per_learner_step * config.arch.num_updates_per_eval
+    total_actual_timesteps = steps_consumed_per_eval * config.arch.num_evaluation
+    print(
+        f"{Fore.RED}{Style.BRIGHT}Warning: Due to the interaction of various factors such as "
+        f"rollout length, number of evaluations, etc... the actual number of timesteps that "
+        f"will be run is {total_actual_timesteps}! This is a difference of "
+        f"{config.arch.total_timesteps - total_actual_timesteps} timesteps! To change this, "
+        f"see total_timestep_checker.py in the utils folder. "
+        f"{Style.RESET_ALL}"
+    )
+
+    assert (
+        config.arch.num_updates > config.arch.num_evaluation
+    ), "Number of updates per evaluation must be less than total number of updates."
+
+    # We then perform a simple check to ensure that the number of envs per actor is
+    # divisible by the number of learner devices. This is because we shard the envs
+    # per actor across the learner devices This check is mainly relevant for on-policy
+    # algorithms
+    assert config.arch.actor.num_envs_per_actor % config.num_learner_devices == 0, (
+        f"The number of envs per actor must be divisible by the number of learner devices. "
+        f"Got {config.arch.actor.num_envs_per_actor} envs per actor "
+        f"and {config.num_learner_devices} learner devices"
     )
 
     return config

--- a/stoix/wrappers/envpool.py
+++ b/stoix/wrappers/envpool.py
@@ -30,7 +30,6 @@ class EnvPoolToJumanji:
         # See if the env has lives - Atari specific
         info = self.env.step(np.zeros(self.num_envs, dtype=int))[-1]
         if "lives" in info and info["lives"].sum() > 0:
-            print("Env has lives")
             self.has_lives = True
         else:
             self.has_lives = False


### PR DESCRIPTION
## What?
Fix issues with actor steps per second and the number of timesteps logged.
## Why?
It had legacy code based on how anakin operates and was incorrect.
## How?
Correctly use num_envs_per_actor * rollout_length as this is what is consumed as a batch by the learner. This multiplied by num updates per eval gives the number of time steps consumed by the learning per eval step.

