### PR TITLE
fix: make FlattenObservationWrapper also flatten next_obs

### DIFF
--- a/stoix/wrappers/transforms.py
+++ b/stoix/wrappers/transforms.py
@@ -31,9 +31,11 @@ class FlattenObservationWrapper(Wrapper):
         timestep = timestep.replace(
             observation=timestep.observation._replace(agent_view=agent_view),
         )
-        if 'next_obs' in timestep.extras:
-            agent_view = self._flatten(timestep.extras['next_obs'])
-            timestep.extras['next_obs'] = timestep.extras['next_obs']._replace(agent_view=agent_view)
+        if "next_obs" in timestep.extras:
+            agent_view = self._flatten(timestep.extras["next_obs"])
+            timestep.extras["next_obs"] = timestep.extras["next_obs"]._replace(
+                agent_view=agent_view
+            )
         return state, timestep
 
     def step(self, state: State, action: chex.Array) -> Tuple[State, TimeStep]:
@@ -42,9 +44,11 @@ class FlattenObservationWrapper(Wrapper):
         timestep = timestep.replace(
             observation=timestep.observation._replace(agent_view=agent_view),
         )
-        if 'next_obs' in timestep.extras:
-            agent_view = self._flatten(timestep.extras['next_obs'])
-            timestep.extras['next_obs'] = timestep.extras['next_obs']._replace(agent_view=agent_view)
+        if "next_obs" in timestep.extras:
+            agent_view = self._flatten(timestep.extras["next_obs"])
+            timestep.extras["next_obs"] = timestep.extras["next_obs"]._replace(
+                agent_view=agent_view
+            )
         return state, timestep
 
     def observation_spec(self) -> Spec:

--- a/stoix/wrappers/transforms.py
+++ b/stoix/wrappers/transforms.py
@@ -21,22 +21,30 @@ class FlattenObservationWrapper(Wrapper):
         obs_shape = self._env.observation_spec().agent_view.shape
         self._obs_shape = (np.prod(obs_shape),)
 
+    def _flatten(self, obs: Observation) -> Array:
+        agent_view = obs.agent_view.astype(jnp.float32)
+        return agent_view.reshape(self._obs_shape)
+
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep]:
         state, timestep = self._env.reset(key)
-        agent_view = timestep.observation.agent_view.astype(jnp.float32)
-        agent_view = agent_view.reshape(self._obs_shape)
+        agent_view = self._flatten(timestep.observation)
         timestep = timestep.replace(
             observation=timestep.observation._replace(agent_view=agent_view),
         )
+        if 'next_obs' in timestep.extras:
+            agent_view = self._flatten(timestep.extras['next_obs'])
+            timestep.extras['next_obs'] = timestep.extras['next_obs']._replace(agent_view=agent_view)
         return state, timestep
 
     def step(self, state: State, action: chex.Array) -> Tuple[State, TimeStep]:
         state, timestep = self._env.step(state, action)
-        agent_view = timestep.observation.agent_view.astype(jnp.float32)
-        agent_view = agent_view.reshape(self._obs_shape)
+        agent_view = self._flatten(timestep.observation)
         timestep = timestep.replace(
             observation=timestep.observation._replace(agent_view=agent_view),
         )
+        if 'next_obs' in timestep.extras:
+            agent_view = self._flatten(timestep.extras['next_obs'])
+            timestep.extras['next_obs'] = timestep.extras['next_obs']._replace(agent_view=agent_view)
         return state, timestep
 
     def observation_spec(self) -> Spec:


### PR DESCRIPTION
## What?

This PR modifies `FlattenObservationWrapper` to also perform the same flattening transform on `next_obs` (right now, the wrapper only modifies the current observation). 

## Why?

Currently, running an algorithm that uses a replay buffer on an environment with non-flat observations will fail (e.g., DQN + gymnax/freeway). The error is one of shapes, caused by `FlattenObservationWrapper` not flattening `extras['next_obs']`.

## How?

Since this change involved duplicating some logic, I also took the liberty of moving a repetitive set of two lines to its own function.

## Extra

Flagging that I'm not familiar enough with Stoix to know whether `if 'next_obs' in timestep.extras:` is the appropriate check/assumption. It looks like `.extras` will always be there, so I don't think this will cause issues, but wanted to bring it to your attention. 
