### PR TITLE
fix: add specific system condition for envpool installation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: [ "commit", "commit-msg", "push" ]
+default_stages: [ "pre-commit", "commit-msg", "pre-push" ]
 default_language_version:
   python: python3
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ chex
 colorama
 craftax
 distrax @ git+https://github.com/google-deepmind/distrax  # distrax release doesn't support jax > 0.4.13
-envpool
+envpool; sys_platform == "linux"
 flashbax @ git+https://github.com/instadeepai/flashbax
 flax
 gymnasium


### PR DESCRIPTION
## What?
Dont install envpool for windows or mac os systems.
## Why?
It breaks installation
## How?
Add specific sys platform condition.