### PR TITLE
feat: switch sebublba to using shard_map like mava

### DIFF
--- a/stoix/configs/arch/sebulba.yaml
+++ b/stoix/configs/arch/sebulba.yaml
@@ -2,19 +2,19 @@
 architecture_name : sebulba
 # --- Training ---
 seed: 42  # RNG seed.
-total_num_envs: 1024  # Total Number of vectorised environments across all actors. Needs to be divisible by the number of actor devices and actors per device.
-total_timesteps: 1e7 # Set the total environment steps.
+total_num_envs: 128  # Total Number of vectorised environments across all actors. Needs to be divisible by the number of actor devices and actors per device.
+total_timesteps: 1e5 # Set the total environment steps.
 # If unspecified, it's derived from num_updates; otherwise, num_updates adjusts based on this value.
 num_updates: ~ # Number of updates
 
 # Define the number of actors per device and which devices to use.
 actor:
-  device_ids: [0,1] # Define which devices to use for the actors.
-  actor_per_device: 2 # number of different threads per actor device.
+  device_ids: [0] # Define which devices to use for the actors.
+  actor_per_device: 1 # number of different threads per actor device.
 
 # Define which devices to use for the learner.
 learner:
-  device_ids: [2,3] # Define which devices to use for the learner.
+  device_ids: [1] # Define which devices to use for the learner.
 
 # Size of the queue for the pipeline where actors push data and the learner pulls data.
 pipeline_queue_size: 10

--- a/stoix/configs/default/sebulba/default_ff_ppo.yaml
+++ b/stoix/configs/default/sebulba/default_ff_ppo.yaml
@@ -1,7 +1,7 @@
 defaults:
   - logger: base_logger
   - arch: sebulba
-  - system: ff_ppo
+  - system: ppo/ff_ppo
   - network: mlp
   - env: envpool/cartpole
   - _self_


### PR DESCRIPTION
## What?
Some mava upgrades, as promised :smile:  
Quite a few nice changes by upgrading to `shard_map` over `pmap` here, which avoids some unnecessary device transfers. I found these in mava using [transfer guard](https://jax.readthedocs.io/en/latest/transfer_guard.html), quite a nice tool.  

## Why?
To make sebulba go brrr
## How?
* Switch to `shard_map`
* Remove the default actor device - this causing some unnecessary transfers in the pipeline
* Stop using flax replicate/unreplicate rather explicitly `put`
* Move a `block_until_ready` from the params source to the learner. I think the `unreplicate` that in the learner before was doing this, without this block we get weird and undefined seg faults
* One issue I see is that we're now passing the same key to all the learners, we are actually doing this in mava also and I realize it is a minor issue, I'm not entirely sure how to fix it, I tried quickly to switch the sharding for the key to the data sharding which I think should fix it, but it didn't...it's Sunday, hopefully I have time to look at it during the week or if you could find a solution that would be awesome 

### NOTE:
This is very much not benchmarked. I pulled in Mava's changes in about an hour and I tested it locally and it solves cartpole, but I haven't checked on a TPU or with a harder env
