### PR TITLE
fix: logger accepts arrays as data and use tensorboard_logger Logger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: [ "commit", "commit-msg", "push" ]
+default_stages: [ "pre-commit", "commit-msg", "pre-push" ]
 default_language_version:
   python: python3
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       - id: commitlint
         name: "Commit linter"
         stages: [ commit-msg ]
-        additional_dependencies: [ '@commitlint/config-conventional' ]
+        additional_dependencies: [ "@commitlint/cli",'@commitlint/config-conventional' ]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/stoix/utils/logger.py
+++ b/stoix/utils/logger.py
@@ -61,7 +61,9 @@ class StoixLogger:
             # {metric1_name: {mean: metric, max: metric, ...}, metric2_name: ...}
             metrics = jax.tree_util.tree_map(describe, metrics)
 
-        metrics = jax.tree.map(lambda x: x.item() if isinstance(x, (jax.Array, np.ndarray)) else x, metrics)
+        metrics = jax.tree.map(
+            lambda x: x.item() if isinstance(x, (jax.Array, np.ndarray)) else x, metrics
+        )
 
         self.logger.log_dict(metrics, t, t_eval, event)
 

--- a/stoix/utils/logger.py
+++ b/stoix/utils/logger.py
@@ -61,7 +61,7 @@ class StoixLogger:
             # {metric1_name: {mean: metric, max: metric, ...}, metric2_name: ...}
             metrics = jax.tree_util.tree_map(describe, metrics)
 
-        metrics = jax.tree.map(lambda x: x.item() if isinstance(x, jax.Array) else x, metrics)
+        metrics = jax.tree.map(lambda x: x.item() if isinstance(x, (jax.Array, np.ndarray)) else x, metrics)
 
         self.logger.log_dict(metrics, t, t_eval, event)
 

--- a/stoix/utils/logger.py
+++ b/stoix/utils/logger.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Union
 import jax
 import neptune
 import numpy as np
+import tensorboard_logger
 import wandb
 from colorama import Fore, Style
 from jax.typing import ArrayLike
@@ -16,7 +17,6 @@ from marl_eval.json_tools import JsonLogger as MarlEvalJsonLogger
 from neptune.utils import stringify_unsupported
 from omegaconf import DictConfig
 from pandas.io.json._normalize import _simple_json_normalize as flatten_dict
-from tensorboard_logger import configure, log_value
 
 
 class LogEvent(Enum):
@@ -60,6 +60,8 @@ class StoixLogger:
             # {metric1_name: [metrics], metric2_name: ...} ->
             # {metric1_name: {mean: metric, max: metric, ...}, metric2_name: ...}
             metrics = jax.tree_util.tree_map(describe, metrics)
+
+        metrics = jax.tree.map(lambda x: x.item() if isinstance(x, jax.Array) else x, metrics)
 
         self.logger.log_dict(metrics, t, t_eval, event)
 
@@ -105,7 +107,13 @@ class BaseLogger(abc.ABC):
         data = flatten_dict(data, sep="/")
 
         for key, value in data.items():
-            self.log_stat(key, value, step, eval_step, event)
+            self.log_stat(
+                key,
+                value,
+                step,
+                eval_step,
+                event,
+            )
 
     def stop(self) -> None:
         """Stop the logger."""
@@ -230,8 +238,8 @@ class TensorboardLogger(BaseLogger):
         tb_exp_path = get_logger_path(cfg, "tensorboard")
         tb_logs_path = os.path.join(cfg.logger.base_exp_path, f"{tb_exp_path}/{unique_token}")
 
-        configure(tb_logs_path)
-        self.log = log_value
+        self.logger = tensorboard_logger.Logger(tb_logs_path)
+        self.log = self.logger.log_value
 
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
         t = step if event != LogEvent.EVAL else eval_step


### PR DESCRIPTION
## What?
I was running experiments with MuZero when I ran into some errors with the loggers. I made changes so that the logger accepts Jax arrays as data to log and uses a tensorboard_logger Logger object instead of a global variable.
## Why?
Somehow, a Jax array gets passed as input to the logger every so often, resulting in an error. 
When using Hydra to perform multiple runs with the Tensorboard logger enabled, an error occurs on the second run due to the logger from the previous run existing and already being configured because it is based on a global variable in the tensorboard_logger library.
## How?
In the case that a Jax array gets passed to the logger, it converts it to a scalar. 
By using an instance of the Logger class instead of a global variable, the Tensorboard logger properly goes out of scope between runs. 
## Extra
I also had issues with running the commit linter step when making the commit because it would say "Please add rules to your `commitlint.config.js`". Making this change to the dependencies resolved it. I'm not sure if it's an issue on my end or not, although I did follow the steps for installing the pre-commit hooks.