### PR TITLE
chore: Redundant duplicate tests and linters workflow in PR's

### DIFF
--- a/.github/workflows/test_linters.yaml
+++ b/.github/workflows/test_linters.yaml
@@ -1,6 +1,6 @@
 name: Tests and Linters 🧪
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   tests-and-linters:


### PR DESCRIPTION
This is a pretty inconsequential change but in pull requests, the testing and listing workflow runs twice as both conditions are satisfied (both a push and a PR), I figured it might be better to remove the "on: push" condition as I can't image this workflow is often needed when not pushing to a PR
