### PR TITLE
feat: pass config env kwargs to gymnax via envparams

### DIFF
--- a/stoix/configs/env/gymnax/breakout.yaml
+++ b/stoix/configs/env/gymnax/breakout.yaml
@@ -5,7 +5,9 @@ scenario:
   name: Breakout-MinAtar
   task_name: breakout
 
-kwargs: {}
+kwargs:
+  use_minimal_action_set: True
+  max_steps_in_episode: 1000
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/utils/make_env.py
+++ b/stoix/utils/make_env.py
@@ -10,6 +10,7 @@ import navix
 import pgx
 import popjym
 import xminigrid
+import dataclasses
 from brax.envs import _envs as brax_environments
 from brax.envs import create as brax_make
 from gymnax import registered_envs as gymnax_environments
@@ -91,8 +92,13 @@ def make_gymnax_env(env_name: str, config: DictConfig) -> Tuple[Environment, Env
     """
     # Config generator and select the wrapper.
     # Create envs.
-    env, env_params = gymnax.make(env_name, **config.env.kwargs)
-    eval_env, eval_env_params = gymnax.make(env_name, **config.env.kwargs)
+    env, env_params = gymnax.make(env_name)
+    eval_env, eval_env_params = gymnax.make(env_name)
+
+    # Modify environment parameters
+    if config.env.kwargs:
+        env_params = dataclasses.replace(env_params, **config.env.kwargs)
+        eval_env_params = dataclasses.replace(eval_env_params, **config.env.kwargs)
 
     env = GymnaxWrapper(env, env_params)
     eval_env = GymnaxWrapper(eval_env, eval_env_params)

--- a/stoix/utils/make_env.py
+++ b/stoix/utils/make_env.py
@@ -1,4 +1,5 @@
 import copy
+import dataclasses
 from typing import Tuple
 
 import gymnax
@@ -10,10 +11,11 @@ import navix
 import pgx
 import popjym
 import xminigrid
-import dataclasses
 from brax.envs import _envs as brax_environments
 from brax.envs import create as brax_make
 from gymnax import registered_envs as gymnax_environments
+from gymnax.environments.environment import Environment as GymnaxEnvironment
+from gymnax.environments.environment import EnvParams as GymnaxEnvParams
 from jaxmarl.environments.smax import map_name_to_scenario
 from jaxmarl.registration import registered_envs as jaxmarl_environments
 from jumanji.env import Environment
@@ -79,6 +81,30 @@ def make_jumanji_env(
     return env, eval_env
 
 
+def _create_gymnax_env_instance(
+    env_name: str, env_kwargs: dict
+) -> Tuple[GymnaxEnvironment, GymnaxEnvParams]:
+    """Helper function to create a single Gymnax env instance with proper kwarg handling.
+
+    This is due to gymnax having both environment init arguments and environment
+    parameters in the EnvParams object."""
+    # Get default params to identify which kwargs are for init and which are for params
+    _, default_params = gymnax.make(env_name)
+    param_fields = {f.name for f in dataclasses.fields(default_params)}
+
+    init_kwargs = {k: v for k, v in env_kwargs.items() if k not in param_fields}
+    params_kwargs = {k: v for k, v in env_kwargs.items() if k in param_fields}
+
+    # Create env, passing only potential init_kwargs
+    env, env_params = gymnax.make(env_name, **init_kwargs)
+
+    # Update params with params_kwargs
+    if params_kwargs:
+        env_params = dataclasses.replace(env_params, **params_kwargs)
+
+    return env, env_params
+
+
 def make_gymnax_env(env_name: str, config: DictConfig) -> Tuple[Environment, Environment]:
     """
     Create a Gymnax environments for training and evaluation.
@@ -90,16 +116,13 @@ def make_gymnax_env(env_name: str, config: DictConfig) -> Tuple[Environment, Env
     Returns:
         A tuple of the environments.
     """
-    # Config generator and select the wrapper.
-    # Create envs.
-    env, env_params = gymnax.make(env_name)
-    eval_env, eval_env_params = gymnax.make(env_name)
+    env_kwargs = dict(copy.deepcopy(config.env.kwargs))
 
-    # Modify environment parameters
-    if config.env.kwargs:
-        env_params = dataclasses.replace(env_params, **config.env.kwargs)
-        eval_env_params = dataclasses.replace(eval_env_params, **config.env.kwargs)
+    # Create envs using the helper function
+    env, env_params = _create_gymnax_env_instance(env_name, env_kwargs)
+    eval_env, eval_env_params = _create_gymnax_env_instance(env_name, env_kwargs)
 
+    # Wrap environments
     env = GymnaxWrapper(env, env_params)
     eval_env = GymnaxWrapper(eval_env, eval_env_params)
 


### PR DESCRIPTION
In gymnax, environment parameters should be modified using `EnvParams`. In fact, currently a non-empty `config.env.kwargs` errors when used with gymnax.