### PR TITLE
Fix WandBLogger

### DIFF
--- a/stoix/configs/logger/logger.yaml
+++ b/stoix/configs/logger/logger.yaml
@@ -10,7 +10,7 @@ loggers:
     _target_: stoix.utils.logger.ConsoleLogger
     enabled: True
   wandb:
-    _target_: stoix.utils.logger.WandbLogger
+    _target_: stoix.utils.logger.WandBLogger
     enabled: False
     # If specified will resume the run with this run ID.
     # This is useful for resuming runs and logging from multiple processes.

--- a/stoix/utils/logger.py
+++ b/stoix/utils/logger.py
@@ -461,6 +461,7 @@ class WandBLogger(BaseLogger):
         tag: list[str],
         group_tag: list[str],
         detailed_logging: bool,
+        architecture_name: str,
         upload_json_data: bool,
         run_id: str | None = None,
         *,


### PR DESCRIPTION
## What?
Fix logging with wandb. For example, `python -m stoix/systems/q_learning/ff_ddqn.py logger.loggers.wandb.enabled=True` gave an error.

## Why?
Logging with wandb was not working due to two issues:
1. The WandBLogger class is misspelled as "WandbLogger" in logger.yaml
2. The WandBLogger class receives an unexpected argument `architecture_name`.

## How?
Fix typo and accept unused argument `architecture_name`.